### PR TITLE
Cleaned up libsensors diagnostics output

### DIFF
--- a/libsensors_monitor/include/libsensors_monitor/libsensors_chip.h
+++ b/libsensors_monitor/include/libsensors_monitor/libsensors_chip.h
@@ -81,7 +81,8 @@ class SensorChipFeature {
 private:
   std::string name_;
   std::string label_;
-  std::string sensor_name_;
+  std::string full_name_;
+  std::string full_label_;
   const SensorChip& chip_;
   sensors_feature const *feature_;
   void enumerate_subfeatures();
@@ -91,9 +92,10 @@ public:
   SensorChipFeature(const SensorChip& chip, sensors_feature const *feature);
   SensorChipSubFeaturePtr getSubFeatureByType(sensors_subfeature_type type);
 
-  const std::string &getName() const {return name_;};
-  const std::string &getLabel() const {return label_;};
-  const std::string &getSensorName() const {return sensor_name_;};
+  const std::string &getFeatureName() const {return name_;};
+  const std::string &getFeatureLabel() const {return label_;};
+  const std::string &getFullName() const {return full_name_;};
+  const std::string &getFullLabel() const {return full_label_;};
   sensors_feature_type getType(){return feature_->type;};
   std::string getChipName(){return chip_.getName();};
 

--- a/libsensors_monitor/package.xml
+++ b/libsensors_monitor/package.xml
@@ -1,7 +1,7 @@
 <package>
   <name>libsensors_monitor</name>
   <version>0.1.2</version>
-  <description>libsensors_monitor</description>
+  <description>A ROS node for using libsensors to provide diagnostics information about the sensors on a computer system.</description>
   <author email="mwills@wpi.edu">Mitchell Wills</author>
   <maintainer email="mwills@wpi.edu">Mitchell Wills</maintainer>
 

--- a/libsensors_monitor/src/libsensors_chip.cpp
+++ b/libsensors_monitor/src/libsensors_chip.cpp
@@ -79,8 +79,8 @@ SensorChip::SensorChip(sensors_chip_name const *chip_name,
     }
 
     if( std::count(ignore.begin(), ignore.end(),
-          feature_ptr->getSensorName()) > 0 ) {
-      ROS_INFO_STREAM("Ignoring sensor " << feature_ptr->getSensorName());
+          feature_ptr->getFullName()) > 0 ) {
+      ROS_INFO_STREAM("Ignoring sensor " << feature_ptr->getFullName());
     } else {
       features_.push_back(feature_ptr);
     }
@@ -93,7 +93,7 @@ SensorChip::SensorChip(sensors_chip_name const *chip_name,
     size_t remain = features_.size();
     BOOST_FOREACH(const SensorChipFeaturePtr & feature, features_) {
       remain--;
-      info_msg << feature->getName();
+      info_msg << feature->getFeatureName();
       if( remain > 0 ) info_msg << ", ";
     }
   } else {
@@ -118,11 +118,12 @@ SensorChipFeature::SensorChipFeature(const SensorChip& chip,
     label_ = label_c_str;
     free(label_c_str);
   }
-  sensor_name_ = getChipName()+"/"+getName();
+  full_name_ = getChipName()+"/"+getFeatureName();
+  full_label_ = getChipName()+"/"+getFeatureLabel();
 
 
-  ROS_DEBUG("\tFound Feature: %s(%s)[%d]", getLabel().c_str(),
-      getName().c_str(), feature_->type);
+  ROS_DEBUG("\tFound Feature: %s(%s)[%d]", getFullLabel().c_str(),
+      getFullName().c_str(), feature_->type);
 
   enumerate_subfeatures();
 }
@@ -164,7 +165,7 @@ double SensorChipSubFeature::getValue(){
   double value;
   if( sensors_get_value(feature_.chip_.internal_name_, subfeature_->number,
         &value) != 0 ) {
-    ROS_WARN_STREAM("Failed to get value for " << feature_.getSensorName() <<
+    ROS_WARN_STREAM("Failed to get value for " << feature_.getFullName() <<
         " " << getName());
   }
   return value;

--- a/libsensors_monitor/src/libsensors_chip.cpp
+++ b/libsensors_monitor/src/libsensors_chip.cpp
@@ -42,6 +42,7 @@
 #include <ros/ros.h>
 #include <boost/foreach.hpp>
 #include <libsensors_monitor/libsensors_chip.h>
+#include <sstream>
 
 #define NAME_BUFFER_SIZE 250
 
@@ -169,6 +170,12 @@ double SensorChipSubFeature::getValue(){
   return value;
 }
 
+static std::string appendUnit(double value, const std::string& unit) {
+  std::stringstream ss;
+  ss << value << unit;
+  return ss.str();
+}
+
 
 void FanSensor::buildStatus(diagnostic_updater::DiagnosticStatusWrapper &stat){
   SensorChipSubFeaturePtr speed = getSubFeatureByType(SENSORS_SUBFEATURE_FAN_INPUT);
@@ -194,12 +201,12 @@ void TempSensor::buildStatus(diagnostic_updater::DiagnosticStatusWrapper &stat){
   SensorChipSubFeaturePtr temp_crit_alarm = getSubFeatureByType(SENSORS_SUBFEATURE_TEMP_CRIT_ALARM);
   if(temp){
     double temp_val = temp->getValue();
-    stat.add("Temperature (\xC2\xB0""C)", temp_val);
+    stat.add("Temperature", appendUnit(temp_val, "\xC2\xB0""C"));
 
     if(max_temp && max_temp->getValue()!=0)
-      stat.add("Max Temperature (\xC2\xB0""C)", max_temp->getValue());
+      stat.add("Max Temperature", appendUnit(max_temp->getValue(), "\xC2\xB0""C"));
     if(temp_crit && temp_crit->getValue()!=0)
-      stat.add("Temperature Critical (\xC2\xB0""C)", temp_crit->getValue());
+      stat.add("Temperature Critical", appendUnit(temp_crit->getValue(), "\xC2\xB0""C"));
 
     if(temp_crit_alarm && temp_crit_alarm->getValue()!=0)
       stat.summaryf(diagnostic_msgs::DiagnosticStatus::WARN,
@@ -246,7 +253,7 @@ void VoltageSensor::buildStatus(diagnostic_updater::DiagnosticStatusWrapper &sta
 
   if(voltage){
     double voltage_val = voltage->getValue();
-    stat.add("Voltage (V)", voltage_val);
+    stat.add("Voltage", appendUnit(voltage_val, "V"));
 
     bool low_warn = false;
     bool low_err = false;
@@ -255,7 +262,7 @@ void VoltageSensor::buildStatus(diagnostic_updater::DiagnosticStatusWrapper &sta
 
     // max voltage (warning)
     if(max) {
-      stat.add("Max Voltage (V)", max->getValue());
+      stat.add("Max Voltage", appendUnit(max->getValue(), "V"));
       if(max_alarm && max_alarm->getValue()!=0) {
         high_warn = true;
       } else if(voltage_val >= max->getValue()) {
@@ -265,7 +272,7 @@ void VoltageSensor::buildStatus(diagnostic_updater::DiagnosticStatusWrapper &sta
 
     // min voltage (warning)
     if(min) {
-      stat.add("Min Voltage (V)", min->getValue());
+      stat.add("Min Voltage", appendUnit(min->getValue(), "V"));
       if(min_alarm && min_alarm->getValue()!=0) {
         low_warn = true;
       } else if(voltage_val <= min->getValue()) {
@@ -274,7 +281,7 @@ void VoltageSensor::buildStatus(diagnostic_updater::DiagnosticStatusWrapper &sta
     }
 
     if(crit) {
-      stat.add("Critical Max Voltage (V)", crit->getValue());
+      stat.add("Critical Max Voltage", appendUnit(crit->getValue(), "V"));
       if(crit_alarm && crit_alarm->getValue()!=0) {
         high_err = true;
       } else if(voltage_val >= crit->getValue()) {
@@ -283,7 +290,7 @@ void VoltageSensor::buildStatus(diagnostic_updater::DiagnosticStatusWrapper &sta
     }
 
     if(lcrit) {
-      stat.add("Critical Min Voltage (V)", lcrit->getValue());
+      stat.add("Critical Min Voltage", appendUnit(lcrit->getValue(), "V"));
       if(lcrit_alarm && lcrit_alarm->getValue()!=0) {
         low_err = true;
       } else if(voltage_val <= lcrit->getValue()) {

--- a/libsensors_monitor/src/libsensors_chip.cpp
+++ b/libsensors_monitor/src/libsensors_chip.cpp
@@ -194,27 +194,27 @@ void TempSensor::buildStatus(diagnostic_updater::DiagnosticStatusWrapper &stat){
   SensorChipSubFeaturePtr temp_crit_alarm = getSubFeatureByType(SENSORS_SUBFEATURE_TEMP_CRIT_ALARM);
   if(temp){
     double temp_val = temp->getValue();
-    stat.add("Temperature (\xB0""C)", temp_val);
+    stat.add("Temperature (\xC2\xB0""C)", temp_val);
 
     if(max_temp && max_temp->getValue()!=0)
-      stat.add("Max Temperature (\xB0""C)", max_temp->getValue());
+      stat.add("Max Temperature (\xC2\xB0""C)", max_temp->getValue());
     if(temp_crit && temp_crit->getValue()!=0)
-      stat.add("Temperature Critical (\xB0""C)", temp_crit->getValue());
+      stat.add("Temperature Critical (\xC2\xB0""C)", temp_crit->getValue());
 
     if(temp_crit_alarm && temp_crit_alarm->getValue()!=0)
       stat.summaryf(diagnostic_msgs::DiagnosticStatus::WARN,
-          "Critical Temp Alarm (%.2f\xB0""C)", temp_val);
+          "Critical Temp Alarm (%.2f\xC2\xB0""C)", temp_val);
     else if(temp_crit && temp_crit->getValue()!=0 &&
         temp_val > temp_crit->getValue())
       stat.summaryf(diagnostic_msgs::DiagnosticStatus::WARN,
-          "Critical Temp Alarm (%.2f\xB0""C)", temp_val);
+          "Critical Temp Alarm (%.2f\xC2\xB0""C)", temp_val);
     else if(max_temp && max_temp->getValue()!=0 &&
         temp_val > max_temp->getValue())
       stat.summaryf(diagnostic_msgs::DiagnosticStatus::WARN,
-          "Max Temp Alarm (%.2f\xB0""C)", temp_val);
+          "Max Temp Alarm (%.2f\xC2\xB0""C)", temp_val);
     else
       stat.summaryf(diagnostic_msgs::DiagnosticStatus::OK,
-          "Temp OK (%.2f\xB0""C)", temp_val);
+          "Temp OK (%.2f\xC2\xB0""C)", temp_val);
   }
   else
     stat.summary(diagnostic_msgs::DiagnosticStatus::ERROR, "NO TEMP Input!!!");

--- a/libsensors_monitor/src/libsensors_chip.cpp
+++ b/libsensors_monitor/src/libsensors_chip.cpp
@@ -171,13 +171,6 @@ double SensorChipSubFeature::getValue(){
   return value;
 }
 
-static std::string appendUnit(double value, const std::string& unit) {
-  std::stringstream ss;
-  ss << value << unit;
-  return ss.str();
-}
-
-
 void FanSensor::buildStatus(diagnostic_updater::DiagnosticStatusWrapper &stat){
   SensorChipSubFeaturePtr speed = getSubFeatureByType(SENSORS_SUBFEATURE_FAN_INPUT);
   if(speed){
@@ -202,27 +195,27 @@ void TempSensor::buildStatus(diagnostic_updater::DiagnosticStatusWrapper &stat){
   SensorChipSubFeaturePtr temp_crit_alarm = getSubFeatureByType(SENSORS_SUBFEATURE_TEMP_CRIT_ALARM);
   if(temp){
     double temp_val = temp->getValue();
-    stat.add("Temperature", appendUnit(temp_val, "\xC2\xB0""C"));
+    stat.add("Temperature (C)", temp_val);
 
     if(max_temp && max_temp->getValue()!=0)
-      stat.add("Max Temperature", appendUnit(max_temp->getValue(), "\xC2\xB0""C"));
+      stat.add("Max Temperature (C)", max_temp->getValue());
     if(temp_crit && temp_crit->getValue()!=0)
-      stat.add("Temperature Critical", appendUnit(temp_crit->getValue(), "\xC2\xB0""C"));
+      stat.add("Temperature Critical (C)", temp_crit->getValue());
 
     if(temp_crit_alarm && temp_crit_alarm->getValue()!=0)
       stat.summaryf(diagnostic_msgs::DiagnosticStatus::WARN,
-          "Critical Temp Alarm (%.2f\xC2\xB0""C)", temp_val);
+          "Critical Temp Alarm (%.2f C)", temp_val);
     else if(temp_crit && temp_crit->getValue()!=0 &&
         temp_val > temp_crit->getValue())
       stat.summaryf(diagnostic_msgs::DiagnosticStatus::WARN,
-          "Critical Temp Alarm (%.2f\xC2\xB0""C)", temp_val);
+          "Critical Temp Alarm (%.2f C)", temp_val);
     else if(max_temp && max_temp->getValue()!=0 &&
         temp_val > max_temp->getValue())
       stat.summaryf(diagnostic_msgs::DiagnosticStatus::WARN,
-          "Max Temp Alarm (%.2f\xC2\xB0""C)", temp_val);
+          "Max Temp Alarm (%.2f C)", temp_val);
     else
       stat.summaryf(diagnostic_msgs::DiagnosticStatus::OK,
-          "Temp OK (%.2f\xC2\xB0""C)", temp_val);
+          "Temp OK (%.2f C)", temp_val);
   }
   else
     stat.summary(diagnostic_msgs::DiagnosticStatus::ERROR, "NO TEMP Input!!!");
@@ -254,7 +247,7 @@ void VoltageSensor::buildStatus(diagnostic_updater::DiagnosticStatusWrapper &sta
 
   if(voltage){
     double voltage_val = voltage->getValue();
-    stat.add("Voltage", appendUnit(voltage_val, "V"));
+    stat.add("Voltage (V)", voltage_val);
 
     bool low_warn = false;
     bool low_err = false;
@@ -263,7 +256,7 @@ void VoltageSensor::buildStatus(diagnostic_updater::DiagnosticStatusWrapper &sta
 
     // max voltage (warning)
     if(max) {
-      stat.add("Max Voltage", appendUnit(max->getValue(), "V"));
+      stat.add("Max Voltage (V)", max->getValue());
       if(max_alarm && max_alarm->getValue()!=0) {
         high_warn = true;
       } else if(voltage_val >= max->getValue()) {
@@ -273,7 +266,7 @@ void VoltageSensor::buildStatus(diagnostic_updater::DiagnosticStatusWrapper &sta
 
     // min voltage (warning)
     if(min) {
-      stat.add("Min Voltage", appendUnit(min->getValue(), "V"));
+      stat.add("Min Voltage (V)", min->getValue());
       if(min_alarm && min_alarm->getValue()!=0) {
         low_warn = true;
       } else if(voltage_val <= min->getValue()) {
@@ -282,7 +275,7 @@ void VoltageSensor::buildStatus(diagnostic_updater::DiagnosticStatusWrapper &sta
     }
 
     if(crit) {
-      stat.add("Critical Max Voltage", appendUnit(crit->getValue(), "V"));
+      stat.add("Critical Max Voltage (V)", crit->getValue());
       if(crit_alarm && crit_alarm->getValue()!=0) {
         high_err = true;
       } else if(voltage_val >= crit->getValue()) {
@@ -291,7 +284,7 @@ void VoltageSensor::buildStatus(diagnostic_updater::DiagnosticStatusWrapper &sta
     }
 
     if(lcrit) {
-      stat.add("Critical Min Voltage", appendUnit(lcrit->getValue(), "V"));
+      stat.add("Critical Min Voltage (V)", lcrit->getValue());
       if(lcrit_alarm && lcrit_alarm->getValue()!=0) {
         low_err = true;
       } else if(voltage_val <= lcrit->getValue()) {
@@ -302,19 +295,19 @@ void VoltageSensor::buildStatus(diagnostic_updater::DiagnosticStatusWrapper &sta
     // check for alarms and set summary
     if(high_err) {
       stat.summaryf(diagnostic_msgs::DiagnosticStatus::ERROR,
-          "High Voltage CRITICAL (%.2fV)", voltage_val);
+          "High Voltage CRITICAL (%.2f V)", voltage_val);
     } else if(low_err) {
       stat.summaryf(diagnostic_msgs::DiagnosticStatus::ERROR,
-          "Low Voltage CRITICAL (%.2fV)", voltage_val);
+          "Low Voltage CRITICAL (%.2f V)", voltage_val);
     } else if(high_warn) {
       stat.summaryf(diagnostic_msgs::DiagnosticStatus::WARN,
-          "High Voltage ALARM (%.2fV)", voltage_val);
+          "High Voltage ALARM (%.2f V)", voltage_val);
     } else if(low_warn) {
       stat.summaryf(diagnostic_msgs::DiagnosticStatus::WARN,
-          "Low Voltage ALARM (%.2fV)", voltage_val);
+          "Low Voltage ALARM (%.2f V)", voltage_val);
     } else {
       stat.summaryf(diagnostic_msgs::DiagnosticStatus::OK,
-          "Voltage OK (%.2fV)", voltage_val);
+          "Voltage OK (%.2f V)", voltage_val);
     }
   } else {
     stat.summary(diagnostic_msgs::DiagnosticStatus::ERROR,

--- a/libsensors_monitor/src/libsensors_monitor.cpp
+++ b/libsensors_monitor/src/libsensors_monitor.cpp
@@ -111,7 +111,7 @@ int main(int argc, char** argv){
   // Add each sensor to the diagnostic updater
   BOOST_FOREACH(SensorChipPtr sensor_chip, sensor_chips_){
     BOOST_FOREACH(SensorChipFeaturePtr sensor, sensor_chip->features_){
-      updater.add(sensor->getSensorName(), boost::bind(&SensorChipFeature::buildStatus, sensor, _1));
+      updater.add(sensor->getFullLabel(), boost::bind(&SensorChipFeature::buildStatus, sensor, _1));
     }
   }
 


### PR DESCRIPTION
Made units consistent with laptop_battery_monitor
Use libsensors label as diagnostics label instead of name