### PR TITLE
add wifi_monitor package

### DIFF
--- a/wifi_monitor/CMakeLists.txt
+++ b/wifi_monitor/CMakeLists.txt
@@ -1,0 +1,28 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(wifi_monitor)
+
+find_package(catkin REQUIRED COMPONENTS
+  diagnostic_msgs
+  message_generation
+  rospy
+  std_msgs
+)
+
+add_message_files(
+  FILES
+  NetworkStatus.msg
+)
+
+generate_messages(
+  DEPENDENCIES
+  std_msgs
+)
+
+catkin_package(CATKIN_DEPENDS diagnostic_msgs message_runtime rospy std_msgs)
+
+install(
+  DIRECTORY scripts launch
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+  USE_SOURCE_PERMISSIONS
+)
+

--- a/wifi_monitor/launch/network_status.launch
+++ b/wifi_monitor/launch/network_status.launch
@@ -1,0 +1,12 @@
+<launch>
+  <arg name="network_interface" default="wlan0" />
+  <arg name="warning_quality" default="0.4" />
+  <arg name="update_rate" default="1.0" />
+
+  <node name="wifi_status"
+        pkg="wifi_monitor" type="network_status.py">
+    <param name="network_interface" value="$(arg network_interface)" />
+    <param name="warning_quality" value="$(arg warning_quality)" />
+    <param name="update_rate" value="$(arg update_rate)" />
+  </node>
+</launch>

--- a/wifi_monitor/msg/NetworkStatus.msg
+++ b/wifi_monitor/msg/NetworkStatus.msg
@@ -1,0 +1,11 @@
+Header header
+string interface
+bool enabled
+bool connected
+string ssid
+float32 frequency # GHz
+string access_point
+float32 bitrate # Mb/s
+int16 tx_power # dBm
+float32 link_quality
+int16 signal_level # dBm

--- a/wifi_monitor/package.xml
+++ b/wifi_monitor/package.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<package>
+  <name>wifi_monitor</name>
+  <version>0.1.4</version>
+  <description>Simple script to monitor wifi status</description>
+  <maintainer email="furushchev@jsk.imi.i.u-tokyo.ac.jp">Yuki Furuta</maintainer>
+  <license>BSD</license>
+  <author email="furushchev@jsk.imi.i.u-tokyo.ac.jp">Yuki Furuta</author>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <build_depend>diagnostic_msgs</build_depend>
+  <build_depend>message_generation</build_depend>
+  <build_depend>rospy</build_depend>
+  <build_depend>std_msgs</build_depend>
+
+  <run_depend>diagnostic_msgs</run_depend>
+  <run_depend>message_runtime</run_depend>
+  <run_depend>rospy</run_depend>
+  <run_depend>std_msgs</run_depend>
+</package>

--- a/wifi_monitor/scripts/network_status.py
+++ b/wifi_monitor/scripts/network_status.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python
+
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2016, JSK Robotics Lab.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of the Willow Garage nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+##\author Yuki Furuta
+##\brief Monitors wifi status
+
+import re
+import subprocess
+import traceback
+
+import rospy
+from diagnostic_msgs.msg import DiagnosticStatus, KeyValue, DiagnosticArray
+from wifi_monitor.msg import NetworkStatus
+
+def extract_number(s):
+    try:
+        extracted = re.match('^[0-9.-]*', s).group()
+        try:
+            return int(extracted)
+        except ValueError:
+            return float(extracted)
+    except:
+        return ''
+
+class Iwconfig(object):
+    def __init__(self, dev):
+        self.dev = dev
+        self.status = {}
+    def fetch(self):
+        try:
+            output = subprocess.check_output(["iwconfig", self.dev],
+                                             stderr=subprocess.STDOUT)
+        except subprocess.CalledProcessError as e:
+            rospy.logdebug("iwconfig command return non-zero code: %s" % str(e.returncode))
+            output = e.output
+        for entity in re.split('\s{2,}', output.replace('=',':').replace('"','')):
+            splitted = entity.split(':')
+            if len(splitted) >= 2:
+                key = entity.split(':')[0].strip()
+                value = ":".join(entity.split(':')[1:]).strip()
+                if "Quality" in key:
+                    q1, q2 = value.split('/')
+                    value = str(float(q1) / float(q2))
+                self.status[key] = value
+    def is_enabled(self):
+        if "ESSID" not in self.status:
+            return False
+        else:
+            return True
+    def is_connected(self):
+        if not self.is_enabled():
+            return False
+        elif "off" in self.status["ESSID"]:
+            return False
+        else:
+            return True
+
+class NetworkStatusPublisherNode(object):
+    def __init__(self):
+        self.ifname = rospy.get_param("~network_interface", "wlan0")
+        self.rate = rospy.get_param("~update_rate", 1.0)
+        self.warn_quality = rospy.get_param("~warning_quality", 0.4)
+        self.iwconfig = Iwconfig(self.ifname)
+        self.status_pub = rospy.Publisher("~status", NetworkStatus, queue_size=1)
+        self.diagnostic_pub = rospy.Publisher("/diagnostics", DiagnosticArray, queue_size=1)
+        self.poll_timer = rospy.Timer(rospy.Rate(self.rate).sleep_dur, self.poll)
+    def poll(self, event=None):
+        self.iwconfig.fetch()
+        self.publish_status()
+        self.publish_diagnostic()
+    def publish_status(self):
+        try:
+            msg = NetworkStatus()
+            msg.header.stamp = rospy.Time.now()
+            msg.interface = self.ifname
+            msg.enabled = self.iwconfig.is_enabled()
+            msg.connected = self.iwconfig.is_connected()
+            if self.iwconfig.is_connected():
+                msg.ssid = self.iwconfig.status["ESSID"]
+                msg.frequency = extract_number(self.iwconfig.status["Frequency"])
+                msg.access_point = self.iwconfig.status["Access Point"]
+                msg.bitrate = extract_number(self.iwconfig.status["Bit Rate"])
+                msg.tx_power = extract_number(self.iwconfig.status["Tx-Power"])
+                msg.link_quality = extract_number(self.iwconfig.status["Link Quality"])
+                msg.signal_level = extract_number(self.iwconfig.status["Signal level"])
+            self.status_pub.publish(msg)
+        except Exception as e:
+            rospy.logerr("Failed to publish status: %s" % str(e))
+            rospy.logerr(traceback.format_exc())
+    def publish_diagnostic(self):
+        try:
+            da = DiagnosticArray()
+            ds = DiagnosticStatus()
+            ds.name = rospy.get_caller_id().lstrip('/') + ': Status'
+            ds.hardware_id = self.ifname
+            if not self.iwconfig.is_enabled():
+                ds.level = DiagnosticStatus.STALE
+                ds.message = "Device not found"
+            elif not self.iwconfig.is_connected():
+                ds.level = DiagnosticStatus.ERROR
+                ds.message = "No connection"
+            else:
+                if extract_number(self.iwconfig.status["Link Quality"]) < self.warn_quality:
+                    ds.level = DiagnosticStatus.WARN
+                    ds.message = "Connected, but bad quality"
+                else:
+                    ds.level = DiagnosticStatus.OK
+                    ds.message = "Connected"
+                for key, val in self.iwconfig.status.items():
+                    ds.values.append(KeyValue(key, val))
+            da.status.append(ds)
+            da.header.stamp = rospy.Time.now()
+            self.diagnostic_pub.publish(da)
+        except Exception as e:
+            rospy.logerr('Failed to publish diagnostic: %s' % str(e))
+            rospy.logerr(traceback.format_exc())
+
+if __name__ == '__main__':
+    rospy.init_node("network_status")
+    n = NetworkStatusPublisherNode()
+    rospy.spin()


### PR DESCRIPTION
this pull request adds `wifi_monitor` package, including nodes publishing wifi network status.

``` bash

---
header: 
  seq: 2
  stamp: 
    secs: 1472354728
    nsecs: 479886054
  frame_id: ''
interface: wlan0
enabled: True
connected: True
ssid: <hidden>
frequency: 2.43700003624
access_point: <hidden>
bitrate: 144.399993896
tx_power: 22A4:12:42:47:E8:FD
link_quality: 0.714285731316
signal_level: -60

---
```

![image](https://cloud.githubusercontent.com/assets/1901008/18031431/17d2d8a4-6d1b-11e6-99ff-3e603021ba69.png)
